### PR TITLE
feat: add skeleton loaders for dashboard and community pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Built with a **React frontend** and **Spring Boot backend**, it ensures your imp
 * 📜 Personal history + community clips
 * ✏️ Update and delete saved clips
 * ⚡ Backend health check for smooth startup
+* 💀 Skeleton loaders for improved perceived performance during data fetching
 
 ---
 

--- a/online-clipboard-frontend/src/pages/Community.jsx
+++ b/online-clipboard-frontend/src/pages/Community.jsx
@@ -18,7 +18,7 @@ export default function Community() {
 
   useEffect(() => {
     loadCommunity();
-  }, [page, activeSearch]); 
+  }, [page, activeSearch]);
 
   const loadCommunity = async () => {
     setLoading(true);
@@ -182,7 +182,54 @@ const downloadFile = async (content, code = "file") => {
           <div className="col-span-1 text-right">Action</div>
         </div>
 
-        {loading && <div className="p-8 text-center text-gray-500 text-sm font-mono animate-pulse">Loading feed...</div>}
+        {loading && (
+          <div className="divide-y divide-gray-800/50 animate-pulse">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="hidden md:grid grid-cols-12 items-center py-4 px-4 gap-4">
+                {/* User */}
+                <div className="col-span-2 flex items-center gap-2">
+                  <div className="w-6 h-6 rounded-full bg-[#1E1E1E] shrink-0" />
+                  <div className="h-3 w-20 bg-[#1E1E1E] rounded" />
+                </div>
+                {/* Code */}
+                <div className="col-span-1">
+                  <div className="h-3 w-10 bg-[#1E1E1E] rounded" />
+                </div>
+                {/* Content */}
+                <div className="col-span-6 pr-4 flex flex-col gap-2">
+                  <div className="h-3 bg-[#1E1E1E] rounded w-3/4" />
+                  <div className="h-3 bg-[#1A1A1A] rounded w-1/2" />
+                </div>
+                {/* Created */}
+                <div className="col-span-2">
+                  <div className="h-3 w-20 bg-[#1E1E1E] rounded" />
+                </div>
+                {/* Action */}
+                <div className="col-span-1 flex justify-end">
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                </div>
+              </div>
+            ))}
+            {/* Mobile skeletons */}
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={`m-${i}`} className="flex md:hidden flex-col gap-3 py-4 px-4">
+                <div className="flex items-center gap-2">
+                  <div className="w-6 h-6 rounded-full bg-[#1E1E1E] shrink-0" />
+                  <div className="h-3 w-24 bg-[#1E1E1E] rounded" />
+                </div>
+                <div className="h-3 bg-[#1E1E1E] rounded w-full" />
+                <div className="h-3 bg-[#1A1A1A] rounded w-2/3" />
+                <div className="flex justify-between pt-2 border-t border-[#141416]">
+                  <div className="flex gap-2">
+                    <div className="h-3 w-12 bg-[#1E1E1E] rounded" />
+                    <div className="h-3 w-20 bg-[#1A1A1A] rounded" />
+                  </div>
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         
         {!loading && clips.length === 0 && (
           <div className="p-12 text-center border-t border-[#141416]">
@@ -198,7 +245,13 @@ const downloadFile = async (content, code = "file") => {
           </div>
         )}
 
-        <div className="divide-y divide-gray-800/50">
+        {!loading && (
+        <motion.div
+          className="divide-y divide-gray-800/50"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
           {clips.map((clip) => (
             <div key={clip.id} className="flex flex-col md:grid md:grid-cols-12 gap-3 md:gap-0 md:items-center py-4 px-4 hover:bg-[#161616] transition-colors group text-sm font-mono items-start md:items-center">
               <div className="md:col-span-2 flex items-center w-full md:w-auto">
@@ -240,10 +293,11 @@ const downloadFile = async (content, code = "file") => {
               </div>
             </div>
           ))}
-        </div>
+        </motion.div>
+        )}
       </div>
 
-     
+
       <div className="flex items-center justify-between border-t border-[#141416] pt-4">
         <button 
           onClick={() => setPage(p => Math.max(0, p - 1))}

--- a/online-clipboard-frontend/src/pages/Dashboard.jsx
+++ b/online-clipboard-frontend/src/pages/Dashboard.jsx
@@ -24,7 +24,7 @@ export default function Dashboard({ user }) {
       // Pass page and pageSize to API
       getUserClips(user.username, page, pageSize)
         .then((data) => {
-          // Note: Backend might return oldest first. 
+          // Note: Backend might return oldest first.
           // If you want consistent sorting on the current page:
           setClips(data.sort((a, b) => b.id - a.id));
         })
@@ -190,10 +190,58 @@ const downloadFile = async (content, code = "file") => {
           <div className="col-span-2 text-right">Actions</div>
         </div>
 
-        {loading && <div className="p-8 text-center text-gray-500 text-sm font-mono animate-pulse">Loading streams...</div>}
+        {loading && (
+          <div className="divide-y divide-gray-800/50 animate-pulse">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="hidden md:grid grid-cols-12 items-center py-4 px-4 gap-4">
+                {/* Code */}
+                <div className="col-span-2">
+                  <div className="h-3.5 w-16 bg-[#1E1E1E] rounded" />
+                </div>
+                {/* Content */}
+                <div className="col-span-6 pr-4 flex flex-col gap-2">
+                  <div className="h-3 bg-[#1E1E1E] rounded w-3/4" />
+                  <div className="h-3 bg-[#1A1A1A] rounded w-1/2" />
+                </div>
+                {/* Created */}
+                <div className="col-span-2">
+                  <div className="h-3 w-20 bg-[#1E1E1E] rounded" />
+                </div>
+                {/* Actions */}
+                <div className="col-span-2 flex justify-end gap-2">
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                </div>
+              </div>
+            ))}
+            {/* Mobile skeletons */}
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={`m-${i}`} className="flex md:hidden flex-col gap-3 py-4 px-4">
+                <div className="flex justify-between">
+                  <div className="h-4 w-16 bg-[#1E1E1E] rounded" />
+                  <div className="h-3 w-24 bg-[#1A1A1A] rounded" />
+                </div>
+                <div className="h-3 bg-[#1E1E1E] rounded w-full" />
+                <div className="h-3 bg-[#1A1A1A] rounded w-2/3" />
+                <div className="flex gap-2 pt-2 border-t border-[#141416]">
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                  <div className="h-7 w-7 bg-[#1E1E1E] rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
         {!loading && filteredClips.length === 0 && <div className="p-12 text-center"><p className="text-gray-500 text-sm">No clips found on this page.</p></div>}
 
-        <div className="divide-y divide-gray-800/50">
+        {!loading && (
+        <motion.div
+          className="divide-y divide-gray-800/50"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.3 }}
+        >
           {filteredClips.map((clip) => (
             <div key={clip.id} className="flex flex-col md:grid md:grid-cols-12 gap-3 md:gap-0 md:items-center py-4 px-4 hover:bg-[#161616] transition-colors group text-sm font-mono">
               {/* Code & Mobile Date */}
@@ -248,7 +296,8 @@ const downloadFile = async (content, code = "file") => {
               </div>
             </div>
           ))}
-        </div>
+        </motion.div>
+        )}
       </div>
 
       {/* Pagination Controls */}


### PR DESCRIPTION
Closes #7 

Added skeleton loaders for clipboard cards in Dashboard and Community pages.
- Replaced plain text loading states with animated skeleton rows
- Matches exact column layout for both desktop and mobile
- Added smooth fade-in transition via framer-motion when data loads

Screenshots
BEFORE:
<img width="1470" height="802" alt="Screenshot 2026-05-03 at 12 28 37 AM" src="https://github.com/user-attachments/assets/d926e7e3-0303-4747-96a0-dbb736efb488" />
<img width="1470" height="802" alt="Screenshot 2026-05-03 at 12 28 56 AM" src="https://github.com/user-attachments/assets/908382e4-a8b0-4d38-99f0-4c03b6b14b29" />

AFTER:
<img width="1470" height="800" alt="Screenshot 2026-05-02 at 11 56 53 PM" src="https://github.com/user-attachments/assets/7b8a93a5-e034-419e-8573-8c0bc6e7e346" />
<img width="1470" height="801" alt="Screenshot 2026-05-02 at 11 59 47 PM" src="https://github.com/user-attachments/assets/31197f33-d57a-4b16-9288-1418a5c6b267" />
<img width="376" height="670" alt="Screenshot 2026-05-03 at 12 03 44 AM" src="https://github.com/user-attachments/assets/a8f9e56b-699c-4ef1-b9f0-0d3a630c4795" />
<img width="375" height="668" alt="Screenshot 2026-05-03 at 12 03 31 AM" src="https://github.com/user-attachments/assets/d6953bde-a68a-45d4-939a-06b7d3f501d9" />

